### PR TITLE
Add Vagrant/Ansible config to project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,10 @@ typings/
 
 # next.js build output
 .next
+
+# vagrant
+.vagrant
+
+# non-local ansible roles
+ansible/roles/*
+!ansible/roles/surface-tension

--- a/README.md
+++ b/README.md
@@ -15,6 +15,24 @@ We created Surface Tension during an Immersive Scholar Residency at NC State whi
 
 The size of the blobs on the map represent increases in 'percentile' of streamflow at each of the ~11K sites, each site comparing only to itself, for the entire period of record. To find out more about the chosen colors and other aspects of the visuals, check out the about page [caitlinandmisha.com/surface-tension](http://caitlinandmisha.com/surface-tension).
 
+### Try it out
+
+Install [VirtualBox](https://www.virtualbox.org/) and [Vagrant](https://www.vagrantup.com)
+
+Clone the repository
+
+    git clone git@github.com:immersive-scholar/surface-tension
+
+Enter the surface-tension directory
+
+    cd surface-tension
+
+Build the environment
+
+    vagrant up
+
+Visit http://localhost:8080
+
 ### Data Caching
 
 Surface Tension consists of a PHP script index.php and a JavaScript-powered html page viz.html. The PHP script's role is to cache USGS streamflow data and provide it to viz.html for display. We first began working on this during the last Government Shutdown and saw warnings about a 'lapse in appropriations' on the USGS websites. This scared us into realizing that as much as data is made available, we shouldn't take it for granted (also in solidarity with initiatives such as [DataRefuge](https://www.datarefuge.org)).

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,42 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # install plugin for sshfs
+  vagrant_plugins = %w(vagrant-sshfs)
+  vagrant_plugins.each do |plugin|
+    unless Vagrant.has_plugin? plugin
+      puts "Plugin #{plugin} is not installed. Install it with:"
+      puts "vagrant plugin install #{vagrant_plugins.join(' ')}"
+      exit
+    end
+  end
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "centos/7"
+
+  # use sshfs for synced port
+  config.vm.synced_folder ".", "/vagrant", type: "sshfs"
+
+
+  # main provisioner
+  config.vm.provision "ansible_local" do |ansible|
+    ansible.galaxy_role_file = 'ansible/requirements.yml'
+    ansible.playbook = 'ansible/playbook.yml'
+    ansible.inventory_path = 'ansible/inventories/development.ini'
+    ansible.limit = 'all'
+  end
+
+  # forwarded ports
+  config.vm.network "forwarded_port", guest: 80, host: 8080, auto_correct: true
+
+end

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,6 @@
+[defaults]
+nocows = 1
+roles_path = ./roles:./imported_roles
+[ssh_connection]
+pipelining=True
+ssh_args = -o ForwardAgent=yes

--- a/ansible/inventories/development.ini
+++ b/ansible/inventories/development.ini
@@ -1,0 +1,2 @@
+[surface-tension]
+localhost    ansible_connection=local

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,0 +1,11 @@
+---
+- hosts: surface-tension
+  gather_facts: yes
+  become: true
+  become_user: root
+  become_method: sudo
+
+  roles:
+    - role: geerlingguy.php
+    - role: surface-tension
+

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,1 @@
+- src: geerlingguy.php

--- a/ansible/roles/surface-tension/handlers/main.yml
+++ b/ansible/roles/surface-tension/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+
+- name: Reload Apache
+  service: name=httpd state=reloaded

--- a/ansible/roles/surface-tension/tasks/main.yml
+++ b/ansible/roles/surface-tension/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: create symlink from surface-tension to app dir
+  file:
+    src: "/vagrant"
+    dest: "/var/www/html/surface-tension"
+    state: link
+
+- name: set selinux to permissive mode
+  shell: "setenforce Permissive"
+
+- name: install apache config
+  template:
+    src: apache.conf.j2
+    dest: '/etc/httpd/conf.d/surface-tension.conf'
+  notify: Reload Apache
+

--- a/ansible/roles/surface-tension/templates/apache.conf.j2
+++ b/ansible/roles/surface-tension/templates/apache.conf.j2
@@ -1,0 +1,5 @@
+<Directory /var/www/html>
+  Options Indexes FollowSymLinks Includes Multiviews
+</Directory>
+
+RedirectMatch ^/$ /surface-tension


### PR DESCRIPTION
This pull request adds Vagrant and Ansible configuration to automatically build a virtual machine, install application dependencies and serve the application. This enables users on different platforms to serve the application in a common environment in only one command (after installing Vagrant/Virtualbox). It should work across macOS, Windows, Linux but I've only tested on macOS so far. I'm willing to make updates if anyone runs into problems on a different OS.